### PR TITLE
Switch variables when overdamping

### DIFF
--- a/Spring.lua
+++ b/Spring.lua
@@ -104,8 +104,8 @@ local Spring = {} do
 		else -- Overdamped
 			local c = sqrt(d*d - 1)
 
-			local r1 = -f*(d - c)
-			local r2 = -f*(d + c)
+			local r1 = -f*(d + c)
+			local r2 = -f*(d - c)
 
 			local co2 = (v0 - offset*r1)/(2*f*c)
 			local co1 = offset - co2


### PR DESCRIPTION
I made a tool that graphs the spring's value over time so I could study how its parameters work. When going beyond 1.00 damping, my formula suddenly changed. (not a problem with my JS implementation as I see it when using this code as well.)

https://user-images.githubusercontent.com/61947825/178050905-24406d9f-9a7f-427b-91ba-5119e714c355.mp4

I found that switching the `r1` and `r2` variables seemed to do the trick, and the graph remains smooth.

https://user-images.githubusercontent.com/61947825/178050951-775bdf89-3233-4f6e-b99a-4d00e2be415d.mp4

