### PR TITLE
Add messages to asserts

### DIFF
--- a/Spring.lua
+++ b/Spring.lua
@@ -15,8 +15,8 @@ local Spring = {} do
 	local EPS = 1e-4
 
 	function Spring.new(dampingRatio: number, frequency: number, position)
-		assert(type(dampingRatio) == "number")
-		assert(type(frequency) == "number")
+		assert(type(dampingRatio) == "number", "Damping ratio must be a number")
+		assert(type(frequency) == "number", "Frequency must be a number")
 		assert(dampingRatio*frequency >= 0, "Spring does not converge")
 
 		return setmetatable({


### PR DESCRIPTION
This addresses an error Selene detects of "A failed assertion without a message is unhelpful to users."